### PR TITLE
chore: switch niobium-client submodule to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submission/niobium-client"]
 	path = submission/niobium-client
-	url = git@github.com:NiobiumInc/niobium-client.git
+	url = https://github.com/NiobiumInc/niobium-client.git

--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ pip install -r requirements.txt
 python3 harness/run_submission.py -h  # Information about command-line options
 ```
 
+#### Submodules
+
+This repository pulls in `submission/niobium-client` as a git submodule. The
+submodule is configured to use HTTPS, so it can be cloned anonymously without a
+GitHub account or SSH key. Be sure to fetch it when cloning:
+
+```console
+git clone --recurse-submodules https://github.com/NiobiumInc/fetch-by-similarity-submission.git
+# or, if you already cloned without submodules:
+git submodule update --init --recursive
+```
+
+If you prefer SSH (for example, because you push to these repositories), there is
+no need to edit `.gitmodules`. Instead, tell git once to rewrite GitHub HTTPS
+URLs to SSH for all your repositories:
+
+```console
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+```
+
 The harness script `harness/run_submission.py` will attempt to build the submission itself, if it is not already built. If already built, it will use the same built code without re-building it, unless the code has changed. The build runs `make release` in `submission/niobium-client`, which builds the bundled OpenFHE, the fhetch library, and the client, and then compiles the submission against that OpenFHE install.
 
 An example run is provided below.


### PR DESCRIPTION
## What

- Switch the `submission/niobium-client` submodule URL in `.gitmodules` from SSH (`git@github.com:...`) to HTTPS (`https://github.com/...`).
- Add a **Submodules** section to the README covering submodule cloning and how to opt back into SSH.

## Why

Now that this repository is public, HTTPS lets anyone clone the submodule anonymously — no GitHub account or SSH key required — which is friendlier for evaluators and submitters.

## SSH opt-in

Rather than documenting a per-repo `.gitmodules` edit (which risks committing a personal SSH URL back into the public repo), the README points SSH-preferring contributors at git's global rewrite, set once:

```
git config --global url."git@github.com:".insteadOf "https://github.com/"
```

This transparently applies to every GitHub HTTPS URL on their machine, with nothing to edit per repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)