### PR TITLE
Add integration-guide link and build fhetch_driver for local replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This execution mode is enabled by passing the `--remote` flag to the harness, an
 This reference repository contains two implementations, one local and one remote, serving as examples of how to use them. Note that closed-source software submissions can use either mode: They can use shims under `submission_remote/` that call a back-end server running the main implementation, or use shims under `submission/` that call a pre-compiled library or a container. That library/container must be included with the submission (e.g. using Github packages).
 
 ## Running the fetch-by-similarity workload
+See also [Running it](https://github.com/NiobiumInc/fetch-by-similarity-submission/blob/main/NIOBIUM_INTEGRATION.md#running-it) in the Niobium integration guide.
+
 #### Dependencies
 - Python 3.12+
 - The build environment for local execution depends on OpenFHE, which is built from the copy bundled inside `submission/niobium-client/vendor/niobium-fhetch/vendor/openfhe` by the niobium-client Makefile. See https://github.com/openfheorg/openfhe-development#installation.

--- a/harness/utils.py
+++ b/harness/utils.py
@@ -52,6 +52,21 @@ def build_submission(script_dir: Path, remote_be: bool):
         # CMake build of the submission itself, pointed at the OpenFHE
         # that niobium-client just installed.
         openfhe_prefix = client_dir / "vendor" / "lib" / "openfhe"
+        # Build the standalone fhetch_driver that "--target local" replay
+        # dispatches to (NBCC_FHETCH_DRIVER in run_submission.py). The
+        # niobium-client "release" build only produces libnbfhetch/fhetch_sim,
+        # not the driver test binary, so configure + build it here against the
+        # OpenFHE install niobium-client just produced (EXTERNAL_OPENFHE=1 so
+        # we don't recompile OpenFHE).
+        fhetch_dir = client_dir / "vendor" / "niobium-fhetch"
+        fhetch_env = {**os.environ,
+                      "OPENFHE_INSTALL_DIR": str(openfhe_prefix),
+                      "EXTERNAL_OPENFHE": "1"}
+        subprocess.run(["make", "-C", str(fhetch_dir), "config-fhetch-release"],
+                       check=True, env=fhetch_env)
+        subprocess.run(["cmake", "--build", str(fhetch_dir / "build"),
+                        "-j", str(os.cpu_count() or 1),
+                        "--target", "fhetch_driver"], check=True)
         subprocess.run([script_dir/"build_task.sh", "./submission", str(openfhe_prefix)], check=True)
 
 


### PR DESCRIPTION
- README: link the "Running it" section of NIOBIUM_INTEGRATION.md from the workload run instructions.
- harness/utils.py: build the standalone fhetch_driver that local replay dispatches to, since the niobium-client release build only produces libnbfhetch/fhetch_sim.