### PR TITLE
activate streaming for polynomials inputs

### DIFF
--- a/submission/src/server_encrypted_compute.cpp
+++ b/submission/src/server_encrypted_compute.cpp
@@ -144,6 +144,10 @@ int main(int argc, char* argv[]) {
   // record/replay decisions. Must run before the crypto context is loaded.
   niobium::compiler().init(argc, argv);
   niobium::compiler().enable_auto_tagging();
+  // Stream tagged input/key data to disk at tag time instead of buffering all
+  // captured input values in RAM until stop(). Safe here: replay happens in a
+  // separate process (cooperative/transport) that reads the .bin from disk.
+  niobium::compiler().enable_input_streaming();
   {
     niobium::Compiler::CacheParameters params;
     params.push_back({"wl", argv[1]});


### PR DESCRIPTION
instead of keeping polynomial in memory stream it directly to disk. this greatly readuces the recording memory footprint, however this disables the in-process replay with the fhetch simulator. the in-process simulator requires that polynomial data is still in memory. the local replay that spawns seperate process still works correctly