### PR TITLE
Enable hollow-mode recording + always-replay in FBS server compute

### DIFF
--- a/NIOBIUM_INTEGRATION.md
+++ b/NIOBIUM_INTEGRATION.md
@@ -17,6 +17,13 @@ Because the trace captures the computation *graph* (not the data), a recorded
 trace can be **replayed with new keys and new inputs** without re-recording, as
 long as the crypto parameters (ring dimension, modulus chain) are unchanged.
 
+Recording uses **hollow mode**: it captures the instruction trace while skipping
+the expensive polynomial math, which keeps the recording run cheap on time and
+memory. The trade-off is that a recording run does not itself produce a usable
+result, so every run — including the first — finishes by replaying the trace to
+get the answer. This makes the first (recording) run a **cold start** that costs
+more than steady-state replays; see [Running it](#running-it).
+
 ## The pieces that changed (and why)
 
 | File | Change |
@@ -41,17 +48,23 @@ The important steps, in order:
    reused. Must be set before the crypto context loads.
 3. **Load** the crypto context, keys, and query the normal OpenFHE way — Niobium
    auto-tags them (and remembers their file paths).
-4. **Gate the computation on `is_cache_valid()`:**
-   - **record** (no trace yet): `start()` → run the real FHE computation →
-     `probe("result", out)` → `stop()`.
-   - **replay** (trace exists): run **no** FHE ops — `replay()` (refreshes any
-     changed input/key files and runs the trace on the target) → `result(cc, "result", out)`.
-5. **Serialize `out`** — identical whether produced by the record run or
-   reconstructed on replay.
+4. **Gate only the *recording* on `is_cache_valid()`, then always replay:**
+   - **record** (no trace yet): `start()` → `enable_hollow_mode(true)` → run the
+     FHE computation in **hollow mode** (the heavy polynomial math is skipped, so
+     recording is fast and low-memory, but the value it leaves in `out` is **not**
+     a valid result) → `enable_hollow_mode(false)` → `probe("result", out)` →
+     `stop()`.
+   - **cache hit** (trace exists): skip recording entirely — run **no** FHE ops.
+   - **then, in both cases:** `replay()` (refreshes any changed input/key files
+     and runs the trace on the target) → `result(cc, "result", out)`. Replay is
+     the only path that yields a correct result — a hollow record computes nothing
+     usable, and a cache hit runs no FHE at all.
+5. **Serialize `out`** — always the ciphertext reconstructed by `replay()`/`result()`.
 
 Rules worth remembering: cache parameters before the context load; **all FHE ops
-inside the `is_cache_valid()` gate** (replay runs zero ops); same crypto
-parameters across record and replay (new key/data values are fine).
+inside the recording gate** (a cache hit runs zero ops); hollow mode must be
+**off** for `probe()`/`stop()`; same crypto parameters across record and replay
+(new key/data values are fine).
 
 ## Running it
 
@@ -68,10 +81,17 @@ python harness/run_submission.py 0 --target <backend>
   unoptimized** (a software FHETCH simulator running on your machine). Use it to
   validate correctness, then switch the target to run on the Niobium backend; the
   workload code does not change.
-- **Record once, replay with new keys:** the first run records the trace; later
-  runs with regenerated keys/data replay it (Niobium refreshes the changed inputs
-  automatically). Keep the recorded trace directory between runs; delete it to
-  force a fresh record after changing the computation or crypto parameters.
+- **Cold start: the first run costs more.** On a cache miss the first run does
+  **both** — it records the trace (in hollow mode: cheap on math and memory, but
+  it still builds and writes the full instruction trace) **and then** replays that
+  trace to produce the result. Later runs hit the cache and **only replay**
+  (Niobium refreshes the changed keys/inputs automatically). So expect the first
+  run after a fresh record — or after changing the computation or crypto
+  parameters, which forces a re-record — to be noticeably slower than the
+  steady-state replays that follow.
+- **Record once, replay with new keys:** keep the recorded trace directory
+  between runs; delete it to force a fresh record (and thus another cold start)
+  after changing the computation or crypto parameters.
 
 ## Build dependency
 

--- a/submission/src/server_encrypted_compute.cpp
+++ b/submission/src/server_encrypted_compute.cpp
@@ -17,13 +17,16 @@
 // When built with NIOBIUM_COMPILER, main() drives Niobium's record/replay
 // lifecycle: it initializes the compiler, enables cooperative auto-tagging (so
 // the crypto context, keys, and input ciphertexts are captured automatically as
-// they are deserialized), and gates the FHE computation on is_cache_valid():
-//   - first run (no trace): RECORD — run the real computation, probe the
-//     output, finalize the trace;
-//   - later runs (trace exists): REPLAY — run NO FHE ops; replay the trace on
-//     the --target backend (or the local simulator) and reconstruct the output.
-// The result ciphertext is then serialized the same way in both cases. Search
-// for "NIOBIUM_COMPILER" below to see each step in context.
+// they are deserialized), and gates only the RECORDING on is_cache_valid():
+//   - cache miss (no trace): RECORD the trace in hollow mode (the FHE math is
+//     skipped for speed/memory, so the value left in the output is NOT valid),
+//     then finalize the trace;
+//   - cache hit (trace exists): skip recording entirely (run NO FHE ops).
+// In BOTH cases it then REPLAYS the trace on the --target backend (or the local
+// simulator) and reconstructs the output — replay is the only path that yields
+// a correct result, since hollow recording does no real math. The result
+// ciphertext is then serialized the same way. Search for "NIOBIUM_COMPILER"
+// below to see each step in context.
 //============================================================================
 #include <cassert>
 
@@ -199,8 +202,10 @@ int main(int argc, char* argv[]) {
 
   auto start_computing = std::chrono::system_clock::now();
 
-  // On record it is produced by the computation below; on a replay
-  // it is reconstructed from the cached trace via result().
+  // `out` is always reconstructed from the trace via replay()+result() below.
+  // On a cache miss the computation below also records the trace in hollow
+  // mode, so the value it leaves in `out` is incorrect and is overwritten by
+  // the replay; on a cache hit the computation is skipped entirely.
   Ciphertext<DCRTPoly> out;
 #ifdef NIOBIUM_COMPILER
   const bool replaying = niobium::compiler().is_cache_valid();
@@ -210,7 +215,8 @@ int main(int argc, char* argv[]) {
 
   if (!replaying) {
 #ifdef NIOBIUM_COMPILER
-    niobium::compiler().start();  // begin recording the FHETCH trace
+    niobium::compiler().start();                    // begin recording the FHETCH trace
+    niobium::compiler().enable_hollow_mode(true);   // skip expensive FHE math while recording
 #endif
   // Matrix-vector multiplication, reading the encrypted matrix one
   // ciphertexe at a time from updir
@@ -388,21 +394,21 @@ int main(int argc, char* argv[]) {
     out = accumulator;
     }  // end else (full payload path)
 #ifdef NIOBIUM_COMPILER
+    niobium::compiler().enable_hollow_mode(false);  // must be OFF for probe/stop
     niobium::compiler().probe("result", out);
     niobium::compiler().stop();  // finalize the trace
 #endif
   }  // end if (!replaying)
 #ifdef NIOBIUM_COMPILER
-  else {
-    // Rreplay: don't run openfhe compution but 
-    // dispatche the replay (local fhetch_driver / remote compiler);
-    // result() reconstructs the output ciphertext.
-    if (!niobium::compiler().replay()) {
-      throw std::runtime_error("niobium replay failed");
-    }
-    if (!niobium::compiler().result(cc, "result", out) || !out) {
-      throw std::runtime_error("niobium result reconstruction failed");
-    }
+  // Always replay to obtain the correct result: hollow-mode recording skips the
+  // real FHE math (so the recorded `out` is incorrect), and the cache-hit path
+  // ran no FHE at all. replay() dispatches to the --target backend (local
+  // fhetch_driver / remote compiler); result() reconstructs the output.
+  if (!niobium::compiler().replay()) {
+    throw std::runtime_error("niobium replay failed");
+  }
+  if (!niobium::compiler().result(cc, "result", out) || !out) {
+    throw std::runtime_error("niobium result reconstruction failed");
   }
 #endif
 


### PR DESCRIPTION
Record in hollow mode on a cache miss, then always replay to get the result. Document the first-run cold-start cost in NIOBIUM_INTEGRATION.md.