### PR TITLE
Add --toy-ring-dim flag for fast TOY runs with ring dimension 2^11

### DIFF
--- a/harness/run_submission.py
+++ b/harness/run_submission.py
@@ -37,6 +37,11 @@ def main():
                              '"local" (default) replays via the in-tree fhetch_driver; any other '
                              'value (e.g. FUNC_SIM_HW) ships the recorded trace to a running '
                              'nbcc_fhetch_replay_server (set NBCC_FHETCH_SERVER for a non-local URL).')
+    parser.add_argument('--toy-ring-dim', dest='toy_ring_dim', action='store_true',
+                        help='Run with reduced ring dimension 2^11 instead of 2^16. '
+                             'Only valid for size 0 (TOY) with --target local. '
+                             'NOTE: 2^11 does not provide 128-bit security; this is '
+                             'for fast functional iteration only.')
     parser.add_argument('--opt-level', dest='opt_level', default='O3',
                         help='Optimization level (O0..O3) for the compiler-side replay. '
                              'Forwarded to server_encrypted_compute and on to the replay '
@@ -45,6 +50,11 @@ def main():
     args, _ = parser.parse_known_args()
     size = args.size
     remote_be = args.remote
+
+    if args.toy_ring_dim:
+        if size != TOY or args.target != 'local' or remote_be:
+            parser.error('--toy-ring-dim is only allowed with size 0 (TOY) '
+                         'and --target local (and without --remote)')
 
     # Use params.py to get instance parameters
     params = InstanceParams(size, args.count_only)
@@ -108,6 +118,10 @@ def main():
     cmd_args = [str(size), ]
     if args.count_only:
         cmd_args.extend(["--count_only"])
+    if args.toy_ring_dim:
+        # Forwarded to every step; the C++ binaries pick it up via
+        # ring_dim_from_args() (params.h), the harness scripts ignore it.
+        cmd_args.extend(["--ring_dim", str(2**11)])
     query_args = cmd_args      # Query steps should not get the global seed
     if args.seed is not None:  # Use seed if provided
         generic_seed = rng.integers(0,0x7fffffff)
@@ -187,6 +201,11 @@ def main():
             compute_args += ["--target", args.target]
             if args.opt_level:
                 compute_args += ["--opt-level", args.opt_level]
+            if args.toy_ring_dim:
+                # 2^11 fails the Niobium hardware compatibility checks
+                # (ring dim != 2^16, primes not = 1 mod 2^16); fine for the
+                # local functional simulator.
+                compute_args += ["--no-ring-dim-check", "--no-prime-check"]
         utils.run_exe_or_python(exec_dir, "server_encrypted_compute", *compute_args)
         utils.log_step(9, "Encrypted computation")
         utils.log_size(io_dir / "ciphertexts_download" / "results.bin" , "Encrypted results")

--- a/submission/include/params.h
+++ b/submission/include/params.h
@@ -40,6 +40,30 @@ inline std::string instance_name(const InstanceSize size) {
     return names[int(size)];
 }
 
+// Scan the command line for "<flag> value" or "<flag>=value" and return
+// the value, or `dflt` if the flag is absent.
+inline std::string arg_value(int argc, char* argv[], const std::string& flag,
+                             const std::string& dflt = "") {
+    for (int i = 1; i < argc; i++) {
+        std::string a = argv[i];
+        if (a == flag && i + 1 < argc) {
+            return argv[i + 1];
+        }
+        if (a.rfind(flag + "=", 0) == 0) {
+            return a.substr(flag.size() + 1);
+        }
+    }
+    return dflt;
+}
+
+// Scan the command line for an optional "--ring_dim N" argument, as
+// forwarded by harness/run_submission.py --toy-ring-dim. Returns 0 if
+// absent, meaning "use the default ring dimension".
+inline int ring_dim_from_args(int argc, char* argv[]) {
+    auto v = arg_value(argc, argv, "--ring_dim");
+    return v.empty() ? 0 : std::stoi(v);
+}
+
 // Parameters that differ for different instance sizes
 class InstanceParams {
     const InstanceSize size;
@@ -50,8 +74,10 @@ class InstanceParams {
     fs::path rootdir; // root of the submission dir structure (see below)
 
 public:
-    // Constructor
-    explicit InstanceParams(InstanceSize _size,
+    // Constructor. _ringDim==0 means the default (65536); a non-default
+    // ring dimension is only supported for the TOY instance (fast local
+    // iteration, NOT cryptographically secure).
+    explicit InstanceParams(InstanceSize _size, int _ringDim = 0,
                             fs::path _rootdir = fs::current_path())
                             : size(_size), rootdir(_rootdir)
     {
@@ -62,7 +88,11 @@ public:
         static const int recDims[] = { 128,   128,     256,      512};
         static const int dbSizes[] = {1000, 50000, 1000000, 20000000};
 
-        ringDim = 65536;
+        ringDim = (_ringDim > 0) ? _ringDim : 65536;
+        if (ringDim != 65536 && _size != InstanceSize::TOY) {
+            throw std::invalid_argument(
+                "A non-default ring dimension is only supported for TOY");
+        }
         recordDim = recDims[int(_size)];
         dbSize    = dbSizes[int(_size)];
 

--- a/submission/src/client_decrypt_decode.cpp
+++ b/submission/src/client_decrypt_decode.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
   auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
-  InstanceParams prms(size);
+  InstanceParams prms(size, ring_dim_from_args(argc, argv));
 
   // Read the encrypted answer from disk
   Ciphertext<DCRTPoly> eres;

--- a/submission/src/client_encode_encrypt_db.cpp
+++ b/submission/src/client_encode_encrypt_db.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
   auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
-  InstanceParams prms(size);
+  InstanceParams prms(size, ring_dim_from_args(argc, argv));
 
   // Read the keys from storage
   auto pk = read_keys(prms);

--- a/submission/src/client_encode_encrypt_query.cpp
+++ b/submission/src/client_encode_encrypt_query.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
   auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
-  InstanceParams prms(size);
+  InstanceParams prms(size, ring_dim_from_args(argc, argv));
 
   // Read the keys from storage
   auto pk = read_keys(prms);

--- a/submission/src/client_key_generation.cpp
+++ b/submission/src/client_key_generation.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
   auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
-  InstanceParams prms(size);
+  InstanceParams prms(size, ring_dim_from_args(argc, argv));
 
   bool count_only = (argc > 2 && std::string(argv[2])=="--count_only");
 
@@ -70,6 +70,12 @@ KeyPair<DCRTPoly> key_gen(const InstanceParams& prms, bool count_only)
   cParams.SetKeySwitchTechnique(HYBRID);
   cParams.SetMultiplicativeDepth(23);
   cParams.SetSecurityLevel(HEStd_128_classic);
+  if (prms.getRingDim() != 65536) {
+    // Reduced ring dimension (TOY fast mode): cannot meet 128-bit security,
+    // so the dimension must be forced with the security check disabled.
+    cParams.SetSecurityLevel(HEStd_NotSet);
+    cParams.SetRingDim(prms.getRingDim());
+  }
   cParams.SetScalingTechnique(FLEXIBLEAUTO);
   cParams.SetScalingModSize(42);
   cParams.SetFirstModSize(57);

--- a/submission/src/client_postprocess.cpp
+++ b/submission/src/client_postprocess.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
     return 0;
   }
   auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
-  InstanceParams prms(size);
+  InstanceParams prms(size, ring_dim_from_args(argc, argv));
 
   bool count_only = (argc > 2 && std::string(argv[2])=="--count_only");
 

--- a/submission/src/server_encrypted_compute.cpp
+++ b/submission/src/server_encrypted_compute.cpp
@@ -133,7 +133,21 @@ int main(int argc, char* argv[]) {
   auto size = static_cast<InstanceSize>(std::stoi(argv[1]));
   bool count_only = (argc > 2 && std::string(argv[2])=="--count_only");
 
-  InstanceParams prms(size);
+  InstanceParams prms(size, ring_dim_from_args(argc, argv));
+
+  // A reduced ring dimension is a local-simulator-only mode: it is not
+  // compatible with the Niobium hardware, so refuse any non-local target
+  // up front — before init()/is_cache_valid(), so a cached reduced-ring
+  // trace can never be dispatched to a remote replay server.
+  if (prms.getRingDim() != 65536) {
+    auto target = arg_value(argc, argv, "--target", "local");
+    if (target != "local") {
+      throw std::runtime_error(
+          "Ring dimension " + std::to_string(prms.getRingDim()) +
+          " is only supported with --target local, not '" + target + "'");
+    }
+  }
+
   constexpr double threshold = 0.8;
   auto timing_fname = prms.iodir()/"server_reported_steps.json";
   auto start_server = std::chrono::system_clock::now();
@@ -155,6 +169,11 @@ int main(int argc, char* argv[]) {
     niobium::Compiler::CacheParameters params;
     params.push_back({"wl", argv[1]});
     params.push_back({"mode", count_only ? "count" : "full"});
+    if (prms.getRingDim() != 65536) {
+      // Keep reduced-ring-dim traces separate from the default cache
+      // (default runs keep their existing cache suffix).
+      params.push_back({"ring", std::to_string(prms.getRingDim())});
+    }
     niobium::compiler().cache_parameters(params);
   }
   niobium::compiler().set_program_info(


### PR DESCRIPTION
## Summary

Adds `run_submission.py 0 --toy-ring-dim`, which runs the TOY instance with ring dimension 2^11 instead of 2^16 for fast local iteration (key gen 0.4s, encrypted compute ~18s end-to-end including recording). This mode is **not cryptographically secure** (key generation switches to `HEStd_NotSet`) and is therefore restricted to size 0 (TOY) with `--target local`.

## Changes

- **harness/run_submission.py**: new `--toy-ring-dim` flag; the parser errors out for any other size, a non-local target, or `--remote`. When set, `--ring_dim 2048` is forwarded to every step, and `--no-ring-dim-check --no-prime-check` to the compute step (2^11 and its primes ≡ 1 mod 4096 fail the Niobium hardware compatibility checks; fine for the local functional simulator).
- **submission/include/params.h**: `InstanceParams` takes an optional ring dimension (validated: non-default is TOY-only), parsed from argv via shared `arg_value()` / `ring_dim_from_args()` helpers.
- **six binaries**: pass `ring_dim_from_args(argc, argv)` into `InstanceParams`. All derived quantities (slots, columns, ciphertext counts) already scale from the ring dim.
- **client_key_generation**: forces the reduced ring dim with `HEStd_NotSet` when non-default (OpenFHE would otherwise bump it back to 2^16).
- **server_encrypted_compute**:
  - adds `ring_2048` to the compiler cache parameters, so a cached 2^16 trace is never replayed against 2^11 data (default cache suffixes unchanged);
  - refuses any non-local `--target` (both `--target X` and `--target=X` forms) when the ring dim is reduced, **before** `init()`/`is_cache_valid()` — so a cached reduced-ring trace can never be dispatched to a remote replay server, even when the binary is invoked directly, bypassing the harness.

## Testing

- `run_submission.py 0 --toy-ring-dim` passes end-to-end (record + local replay, verify PASS), and seeded re-runs pass via the cache-hit/replay-only path with nonzero matches (18 and 10 payload vectors).
- Guard tests: `1 --toy-ring-dim` and `0 --toy-ring-dim --target FUNC_SIM_HW` are rejected by the harness; direct binary invocation `server_encrypted_compute 0 --ring_dim 2048 --target FUNC_SIM_HW --no-ring-dim-check --no-prime-check` (with the 2048 trace cached) aborts with a clear error before any compiler interaction; the same invocation with `--target local` replays successfully.
- Default-path behavior is unchanged: no new cache-parameter entries, and the key-gen override is a no-op at ring dim 65536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)