### PR TITLE
Document the FOG replay target

### DIFF
--- a/NIOBIUM_INTEGRATION.md
+++ b/NIOBIUM_INTEGRATION.md
@@ -75,12 +75,22 @@ python harness/run_submission.py 0 --target local
 # Backend target: ships the trace to the Niobium compiler. Start a server first
 # (see scripts/start_fhetch_server.py) and select the target.
 python harness/run_submission.py 0 --target <backend>
+
+# FPGA hardware: FOG runs on Niobium's stable FPGA device. The server resolves
+# it to the currently pinned hardware id — you never name a device directly.
+python harness/run_submission.py 0 --target FOG
 ```
 
 - **`--target local` is for debugging only — it is intentionally slow and
   unoptimized** (a software FHETCH simulator running on your machine). Use it to
   validate correctness, then switch the target to run on the Niobium backend; the
   workload code does not change.
+- **`--target FOG` is the recommended way to run on FPGA hardware.** It is a
+  stable public alias: the replay server translates it to whatever FPGA device
+  is currently promoted as stable (pinned server-side), so submissions keep
+  working across device upgrades without changing any flags. Any other target
+  value is passed through to the server verbatim, for when you do need a
+  specific internal device.
 - **Cold start: the first run costs more.** On a cache miss the first run does
   **both** — it records the trace (in hollow mode: cheap on math and memory, but
   it still builds and writes the full instruction trace) **and then** replays that

--- a/harness/run_submission.py
+++ b/harness/run_submission.py
@@ -35,8 +35,12 @@ def main():
     parser.add_argument('--target', default='local',
                         help='Replay target for server_encrypted_compute (cooperative mode). '
                              '"local" (default) replays via the in-tree fhetch_driver; any other '
-                             'value (e.g. FUNC_SIM_HW) ships the recorded trace to a running '
-                             'nbcc_fhetch_replay_server (set NBCC_FHETCH_SERVER for a non-local URL).')
+                             'value ships the recorded trace to a running '
+                             'nbcc_fhetch_replay_server (set NBCC_FHETCH_SERVER for a non-local URL). '
+                             'Use "FOG" to run on Niobium\'s stable FPGA device — the server '
+                             'resolves it to its pinned hardware id, so you never need to know '
+                             'internal device names. Other values (e.g. FUNC_SIM_HW) are '
+                             'forwarded to the server verbatim.')
     parser.add_argument('--toy-ring-dim', dest='toy_ring_dim', action='store_true',
                         help='Run with reduced ring dimension 2^11 instead of 2^16. '
                              'Only valid for size 0 (TOY) with --target local. '


### PR DESCRIPTION
## Summary

Documentation for the new `--target FOG` alias (behavior lands in NiobiumInc/niobium-compiler#1796): FOG runs the workload on Niobium's stable FPGA device, with the replay server resolving the alias to its currently pinned hardware id. Users never name internal devices, and submissions keep working across device promotions without flag changes.

## Changes

- `harness/run_submission.py` — `--target` help recommends FOG for FPGA runs and notes that other values are forwarded to the server verbatim.
- `NIOBIUM_INTEGRATION.md` — adds a `--target FOG` example to the "Running it" section plus a bullet explaining the alias and when to pass a specific internal device instead.

No behavior changes — the harness already forwards any `--target` value through the transport untouched.

needs to wait for other PRs