### PR TITLE
harness: default local replay to fhetch_sim, gate driver behind --use-driver

### DIFF
--- a/harness/run_submission.py
+++ b/harness/run_submission.py
@@ -34,8 +34,8 @@ def main():
                         help='Run example submission in remote backend mode')
     parser.add_argument('--target', default='local',
                         help='Replay target for server_encrypted_compute (cooperative mode). '
-                             '"local" (default) replays via the in-tree fhetch_driver; any other '
-                             'value ships the recorded trace to a running '
+                             '"local" (default) replays via the in-tree fhetch_sim project '
+                             'worker; any other value ships the recorded trace to a running '
                              'nbcc_fhetch_replay_server (set NBCC_FHETCH_SERVER for a non-local URL). '
                              'Use "FOG" to run on Niobium\'s stable FPGA device — the server '
                              'resolves it to its pinned hardware id, so you never need to know '
@@ -46,6 +46,11 @@ def main():
                              'Only valid for size 0 (TOY) with --target local. '
                              'NOTE: 2^11 does not provide 128-bit security; this is '
                              'for fast functional iteration only.')
+    parser.add_argument('--use-driver', action='store_true',
+                        help='For --target local: replay via the fhetch_driver roundtrip '
+                             'harness (re-drives the trace through the recording API — an '
+                             'API-coverage check, much heavier on memory) instead of the '
+                             'default fhetch_sim project worker.')
     parser.add_argument('--opt-level', dest='opt_level', default='O3',
                         help='Optimization level (O0..O3) for the compiler-side replay. '
                              'Forwarded to server_encrypted_compute and on to the replay '
@@ -68,7 +73,7 @@ def main():
     utils.ensure_directories(params.rootdir)
 
     # Verify dependencies and build the submission, if not built already
-    utils.build_submission(params.rootdir/"scripts", remote_be)
+    utils.build_submission(params.rootdir/"scripts", remote_be, args.use_driver)
 
     # The harness scripts are in the 'harness' directory,
     # the submission code is either in submission or submission_remote
@@ -77,9 +82,10 @@ def main():
 
     # Cooperative record/replay env for server_encrypted_compute (Niobium).
     # The binary owns the explicit lifecycle; its replay() dispatches a disk
-    # replay — local via the in-tree fhetch_driver (NBCC_FHETCH_DRIVER), or for
-    # a non-local --target via the transport forwarder (NBCC_FHETCH_REPLAY) to a
-    # running server (NBCC_FHETCH_SERVER, default http://127.0.0.1:9443).
+    # replay — local via the in-tree fhetch_sim project worker (NBCC_FHETCH_SIM;
+    # fhetch_driver roundtrip harness with --use-driver), or for a non-local
+    # --target via the transport forwarder (NBCC_FHETCH_REPLAY) to a running
+    # server (NBCC_FHETCH_SERVER, default http://127.0.0.1:9443).
     if not remote_be:
         client_dir = params.rootdir / "submission" / "niobium-client"
         openfhe_lib = client_dir / "vendor" / "lib" / "openfhe" / "lib"
@@ -92,9 +98,20 @@ def main():
             prev = os.environ.get(var)
             os.environ[var] = os.pathsep.join([str(openfhe_lib)] + ([prev] if prev else []))
         if args.target == "local":
-            os.environ["NBCC_FHETCH_DRIVER"] = str(
-                client_dir / "vendor" / "niobium-fhetch" / "build" / "tests"
-                / "fhetch_driver" / "fhetch_driver")
+            if args.use_driver:
+                # Opt into the roundtrip verification harness (the library
+                # only takes this path when NBCC_FHETCH_DRIVER is set). The
+                # driver is built standalone in the fhetch submodule's own
+                # build dir by utils.build_submission.
+                os.environ["NBCC_FHETCH_DRIVER"] = str(
+                    client_dir / "vendor" / "niobium-fhetch" / "build"
+                    / "tests" / "fhetch_driver" / "fhetch_driver")
+            else:
+                # fhetch_sim is built by the client's own release build,
+                # inside the client's CMake tree.
+                os.environ.pop("NBCC_FHETCH_DRIVER", None)
+                os.environ["NBCC_FHETCH_SIM"] = str(
+                    client_dir / "build" / "vendor" / "niobium-fhetch" / "fhetch_sim")
         else:
             os.environ["NBCC_FHETCH_REPLAY"] = str(
                 client_dir / "build" / "src" / "fhetch_transport" / "nbcc_fhetch_replay")

--- a/harness/utils.py
+++ b/harness/utils.py
@@ -36,7 +36,7 @@ def ensure_directories(rootdir: Path):
                   f"not found in {rootdir}")
             sys.exit(1)
 
-def build_submission(script_dir: Path, remote_be: bool):
+def build_submission(script_dir: Path, remote_be: bool, use_driver: bool = False):
     """
     Build the submission, including pulling dependencies as neeed
     """
@@ -44,29 +44,31 @@ def build_submission(script_dir: Path, remote_be: bool):
         subprocess.run([sys.executable, "-m", "pip", "install", "-r", "./submission_remote/requirements.txt"], check=True)
     else:
         # Build the niobium-client submodule, which builds its bundled
-        # OpenFHE (under vendor/lib/openfhe), the fhetch library, and
-        # the client examples. We use this OpenFHE for the submission
-        # build instead of scripts/get_openfhe.sh.
+        # OpenFHE (under vendor/lib/openfhe), the fhetch library, and the
+        # client examples — including the fhetch_sim project worker that
+        # default "--target local" replay dispatches to. We use this
+        # OpenFHE for the submission build instead of scripts/get_openfhe.sh.
         client_dir = script_dir.parent / "submission" / "niobium-client"
         subprocess.run(["make", "-C", str(client_dir), "release"], check=True)
         # CMake build of the submission itself, pointed at the OpenFHE
         # that niobium-client just installed.
         openfhe_prefix = client_dir / "vendor" / "lib" / "openfhe"
-        # Build the standalone fhetch_driver that "--target local" replay
-        # dispatches to (NBCC_FHETCH_DRIVER in run_submission.py). The
-        # niobium-client "release" build only produces libnbfhetch/fhetch_sim,
-        # not the driver test binary, so configure + build it here against the
-        # OpenFHE install niobium-client just produced (EXTERNAL_OPENFHE=1 so
-        # we don't recompile OpenFHE).
-        fhetch_dir = client_dir / "vendor" / "niobium-fhetch"
-        fhetch_env = {**os.environ,
-                      "OPENFHE_INSTALL_DIR": str(openfhe_prefix),
-                      "EXTERNAL_OPENFHE": "1"}
-        subprocess.run(["make", "-C", str(fhetch_dir), "config-fhetch-release"],
-                       check=True, env=fhetch_env)
-        subprocess.run(["cmake", "--build", str(fhetch_dir / "build"),
-                        "-j", str(os.cpu_count() or 1),
-                        "--target", "fhetch_driver"], check=True)
+        if use_driver:
+            # Build the standalone fhetch_driver that --use-driver replay
+            # dispatches to (NBCC_FHETCH_DRIVER in run_submission.py). The
+            # niobium-client "release" build only produces libnbfhetch/
+            # fhetch_sim, not the driver test binary, so configure + build it
+            # here against the OpenFHE install niobium-client just produced
+            # (EXTERNAL_OPENFHE=1 so we don't recompile OpenFHE).
+            fhetch_dir = client_dir / "vendor" / "niobium-fhetch"
+            fhetch_env = {**os.environ,
+                          "OPENFHE_INSTALL_DIR": str(openfhe_prefix),
+                          "EXTERNAL_OPENFHE": "1"}
+            subprocess.run(["make", "-C", str(fhetch_dir), "config-fhetch-release"],
+                           check=True, env=fhetch_env)
+            subprocess.run(["cmake", "--build", str(fhetch_dir / "build"),
+                            "-j", str(os.cpu_count() or 1),
+                            "--target", "fhetch_driver"], check=True)
         subprocess.run([script_dir/"build_task.sh", "./submission", str(openfhe_prefix)], check=True)
 
 


### PR DESCRIPTION

The niobium-fhetch library's `--target local` replay now dispatches to the `fhetch_sim` project worker by default (NiobiumInc/niobium-fhetch PR #99); the `fhetch_driver` roundtrip harness is an explicit opt-in via `NBCC_FHETCH_DRIVER`.

Harness changes:

- `--target local` sets `NBCC_FHETCH_SIM` to the `fhetch_sim` binary the niobium-client release build already produces (inside the client's CMake tree) — no extra build step.
- New `--use-driver` flag opts into the roundtrip harness (re-drives the trace through the recording API — an API-coverage check, much heavier on memory) and gates the extra `fhetch_driver` cmake build that used to run unconditionally.


**Merge order:** depends on the niobium-fhetch dispatch change being vendored into niobium-client (submodule bump) first — with an older vendored library, the harness no longer setting `NBCC_FHETCH_DRIVER` would leave local replay looking for `fhetch_driver` on PATH.
